### PR TITLE
(chart/sftpgo) feat: add hostnetwork support for pods

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.5.3
+version: 0.5.4
 appVersion: 2.0.4
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -19,7 +19,6 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - Remove test files from final Helm package
     - Add hostNetwork field to the deployment
   artifacthub.io/images: |
     - name: sftpgo

--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -20,6 +20,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - Remove test files from final Helm package
+    - Add hostNetwork field to the deployment
   artifacthub.io/images: |
     - name: sftpgo
       image: ghcr.io/drakkan/sftpgo:v2.0.4

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.5.3](https://img.shields.io/badge/version-0.5.3-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.0.4](https://img.shields.io/badge/app%20version-2.0.4-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.5.4](https://img.shields.io/badge/version-0.5.4-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.0.4](https://img.shields.io/badge/app%20version-2.0.4-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 
@@ -120,6 +120,7 @@ require at least one port.
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | podAnnotations | object | `{}` | Annotations to be added to pods. |
 | podSecurityContext | object | `{}` | Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details. |
+| hostNetwork | bool | `false` | Run pods in the host network of nodes. Warning: The use of host network is [discouraged](https://kubernetes.io/docs/concepts/configuration/overview/#services). Make sure to use it only when absolutely necessary. |
 | securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 | service.annotations | object | `{}` | Annotations to be added to the service. |
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sftpgo.serviceAccountName" . }}
+      hostNetwork: {{ .Values.hostNetwork }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -75,6 +75,9 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
+# -- Share node's network interfaces with the Pods
+hostNetwork: false
+
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
 securityContext: {}

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -75,7 +75,8 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-# -- Share node's network interfaces with the Pods
+# -- Run pods in the host network of nodes.
+# Warning: The use of host network is [discouraged](https://kubernetes.io/docs/concepts/configuration/overview/#services). Make sure to use it only when absolutely necessary.
 hostNetwork: false
 
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).


### PR DESCRIPTION
Hi,

I've got a need for binding my sftpgo servers to IPs tied to the node on which they're running.
For that, I need the Pod to share the node's network interfaces.

I've added to the chart a value to switch on or off the hostNetwork directive on the deployment (false by default).

Thanks for the chart !