### PR TITLE
Adding extraArgs

### DIFF
--- a/charts/caddy/Chart.yaml
+++ b/charts/caddy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: caddy
-version: 0.0.11
+version: 0.0.12
 appVersion: "2.3.0"
 kubeVersion: ">=1.16.0-0"
 description: A powerful, enterprise-ready, open source web server with automatic HTTPS written in Go.

--- a/charts/caddy/README.md
+++ b/charts/caddy/README.md
@@ -1,6 +1,6 @@
 # caddy
 
-![version: 0.0.11](https://img.shields.io/badge/version-0.0.11-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.3.0](https://img.shields.io/badge/app%20version-2.3.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-caddy-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/caddy)
+![version: 0.0.12](https://img.shields.io/badge/version-0.0.12-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.3.0](https://img.shields.io/badge/app%20version-2.3.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-caddy-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/caddy)
 
 A powerful, enterprise-ready, open source web server with automatic HTTPS written in Go.
 
@@ -32,6 +32,7 @@ HTTPS service support, metrics and a lot of other features are coming in later v
 | fullnameOverride | string | `""` | A name to substitute for the full names of resources. |
 | config | string | `nil` | Caddy configuration file content. Accepts [Caddyfile](https://caddyserver.com/docs/caddyfile) format by default. See `adapter` for other formats. |
 | adapter | string | `"caddyfile"` | Caddyfile [config adapter](https://caddyserver.com/docs/config-adapters). Set it to empty string to use JSON. |
+| extraArgs | list | `[]` | Additional command line arguments for `caddy run`. |
 | volumes | list | `[]` | Additional storage [volumes](https://kubernetes.io/docs/concepts/storage/volumes/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |
 | volumeMounts | list | `[]` | Additional [volume mounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |
 | envFrom | list | `[]` | Additional environment variables mounted from [secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) or [config maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details. |

--- a/charts/caddy/README.md
+++ b/charts/caddy/README.md
@@ -32,7 +32,7 @@ HTTPS service support, metrics and a lot of other features are coming in later v
 | fullnameOverride | string | `""` | A name to substitute for the full names of resources. |
 | config | string | `nil` | Caddy configuration file content. Accepts [Caddyfile](https://caddyserver.com/docs/caddyfile) format by default. See `adapter` for other formats. |
 | adapter | string | `"caddyfile"` | Caddyfile [config adapter](https://caddyserver.com/docs/config-adapters). Set it to empty string to use JSON. |
-| extraArgs | list | `[]` | Additional command line arguments for `caddy run`. |
+| watch | bool | `false` | Watch config file for changes and reload it automatically. |
 | volumes | list | `[]` | Additional storage [volumes](https://kubernetes.io/docs/concepts/storage/volumes/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |
 | volumeMounts | list | `[]` | Additional [volume mounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |
 | envFrom | list | `[]` | Additional environment variables mounted from [secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) or [config maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details. |

--- a/charts/caddy/templates/deployment.yaml
+++ b/charts/caddy/templates/deployment.yaml
@@ -14,7 +14,9 @@ spec:
   template:
     metadata:
       annotations:
+      {{- if not (or (has "-watch" .Values.extraArgs) (has "--watch" .Values.extraArgs)) }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -42,6 +44,9 @@ spec:
             {{- if and .Values.config .Values.adapter }}
             - --adapter
             - {{ .Values.adapter }}
+            {{- end }}
+            {{- with .Values.extraArgs }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.env }}
           env:

--- a/charts/caddy/templates/deployment.yaml
+++ b/charts/caddy/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if not (or (has "-watch" .Values.extraArgs) (has "--watch" .Values.extraArgs)) }}
+      {{- if not .Values.watch }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- end }}
       {{- with .Values.podAnnotations }}
@@ -45,8 +45,8 @@ spec:
             - --adapter
             - {{ .Values.adapter }}
             {{- end }}
-            {{- with .Values.extraArgs }}
-              {{- toYaml . | nindent 12 }}
+            {{- if .Values.watch }}
+            - --watch
             {{- end }}
           {{- with .Values.env }}
           env:

--- a/charts/caddy/values.yaml
+++ b/charts/caddy/values.yaml
@@ -31,6 +31,9 @@ config:
 # -- Caddyfile [config adapter](https://caddyserver.com/docs/config-adapters). Set it to empty string to use JSON.
 adapter: caddyfile
 
+# -- Additional command line arguments for `caddy run`.
+extraArgs: []
+
 # -- Additional storage [volumes](https://kubernetes.io/docs/concepts/storage/volumes/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details.
 volumes: []

--- a/charts/caddy/values.yaml
+++ b/charts/caddy/values.yaml
@@ -31,8 +31,8 @@ config:
 # -- Caddyfile [config adapter](https://caddyserver.com/docs/config-adapters). Set it to empty string to use JSON.
 adapter: caddyfile
 
-# -- Additional command line arguments for `caddy run`.
-extraArgs: []
+# -- Watch config file for changes and reload it automatically.
+watch: false
 
 # -- Additional storage [volumes](https://kubernetes.io/docs/concepts/storage/volumes/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details.


### PR DESCRIPTION
This PR is adding `extraArgs` key that can be used to add additional command line arguments for the `caddy run` command:

```yaml
extraArgs:
  - --watch
```

When the `-watch` or the `--watch` is specified in the `extraArgs` list, the `checksum/config` annotation is ignored in the `Deployment`.