### PR TITLE
Make probes configurable

### DIFF
--- a/charts/caddy/Chart.yaml
+++ b/charts/caddy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: caddy
-version: 0.0.12
+version: 0.0.13
 appVersion: "2.3.0"
 kubeVersion: ">=1.16.0-0"
 description: A powerful, enterprise-ready, open source web server with automatic HTTPS written in Go.

--- a/charts/caddy/README.md
+++ b/charts/caddy/README.md
@@ -1,6 +1,6 @@
 # caddy
 
-![version: 0.0.12](https://img.shields.io/badge/version-0.0.12-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.3.0](https://img.shields.io/badge/app%20version-2.3.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-caddy-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/caddy)
+![version: 0.0.13](https://img.shields.io/badge/version-0.0.13-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.3.0](https://img.shields.io/badge/app%20version-2.3.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-caddy-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/caddy)
 
 A powerful, enterprise-ready, open source web server with automatic HTTPS written in Go.
 
@@ -60,3 +60,5 @@ HTTPS service support, metrics and a lot of other features are coming in later v
 | nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration. |
 | tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for node taints. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
+| livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | [Liveness probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) for details. |
+| readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | [Readiness probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes) See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) for details. |

--- a/charts/caddy/templates/deployment.yaml
+++ b/charts/caddy/templates/deployment.yaml
@@ -64,13 +64,9 @@ spec:
               containerPort: 80
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.config .Values.volumeMounts }}

--- a/charts/caddy/values.yaml
+++ b/charts/caddy/values.yaml
@@ -164,3 +164,17 @@ tolerations: []
 # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration.
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details.
 affinity: {}
+
+# -- [Liveness probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes)
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) for details.
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# -- [Readiness probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes)
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Probe) for details.
+readinessProbe:
+  httpGet:
+    path: /
+    port: http


### PR DESCRIPTION
This PR makes probes configurable for the case when the server doesn't respond with `2xx` by default (e.g. when using [`basicauth`](https://caddyserver.com/docs/caddyfile/directives/basicauth)). In such case, this configuration can be used to make the probes still work:

```yaml
livenessProbe:
  httpGet:
    path: /-/healthcheck

readinessProbe:
  httpGet:
    path: /-/healthcheck

config: |
  :80 {
    handle /-/healthcheck {
      respond 200
    }

    handle {
      basicauth {
        Bob JDJhJDEwJEVCNmdaNEg2Ti5iejRMYkF3MFZhZ3VtV3E1SzBWZEZ5Q3VWc0tzOEJwZE9TaFlZdEVkZDhX
      }

      reverse_proxy myservice:1234 {
        header_up X-User {http.auth.user.id}
      }
    }
  }
```

Please merge after PR #90 to keep the chart version in order.

Fixes #68