### PR TITLE
sftpgo: Add Ingress support

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.8.1
+version: 0.9.0
 appVersion: 2.1.0
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.9.0](https://img.shields.io/badge/version-0.9.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.1.0](https://img.shields.io/badge/app%20version-2.1.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.9.1-1](https://img.shields.io/badge/version-0.9.1--1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.1.0](https://img.shields.io/badge/app%20version-2.1.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 
@@ -136,16 +136,16 @@ require at least one port.
 | service.ports.http.nodePort | int | `nil` | REST API node port (when applicable). |
 | service.externalTrafficPolicy | string | `nil` | Route external traffic to node-local or cluster-wide endoints. Useful for [preserving the client source IP](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip). |
 | services | object | `{}` | Additional services exposing servers (SFTP, FTP, WebDAV, HTTP) individually. The schema matches the one under the `service` key. Additional services need at least one port. |
-| ingress.app.enabled | bool | `false` | Create an Ingress for the user and admin Web UI |
-| ingress.app.className | string | `""` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
-| ingress.app.annotations | object | `{}` | Annotations to be added to the Ingress. |
-| ingress.app.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
-| ingress.app.tls | list | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
-| ingress.api.enabled | bool | `false` | Create an Ingress for the API and health endpoint. |
-| ingress.api.className | string | `""` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
-| ingress.api.annotations | object | `{}` | Annotations to be added to the Ingress. |
-| ingress.api.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
-| ingress.api.tls | list | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ui.ingress.enabled | bool | `false` | Create an Ingress for the user and admin Web UI |
+| ui.ingress.className | string | `""` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ui.ingress.annotations | object | `{}` | Annotations to be added to the Ingress. |
+| ui.ingress.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ui.ingress.tls | list | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| api.ingress.enabled | bool | `false` | Create an Ingress for the API and health endpoint. |
+| api.ingress.className | string | `""` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| api.ingress.annotations | object | `{}` | Annotations to be added to the Ingress. |
+| api.ingress.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. sftpgo does not change the path for the health check and API endpoint if httpd.web_root is set. So, we need to rewrite these paths to the root. |
+| api.ingress.tls | list | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling configuration (see [values.yaml](values.yaml) for details). |
 | nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration. |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -136,7 +136,7 @@ require at least one port.
 | service.ports.http.nodePort | int | `nil` | REST API node port (when applicable). |
 | service.externalTrafficPolicy | string | `nil` | Route external traffic to node-local or cluster-wide endoints. Useful for [preserving the client source IP](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip). |
 | services | object | `{}` | Additional services exposing servers (SFTP, FTP, WebDAV, HTTP) individually. The schema matches the one under the `service` key. Additional services need at least one port. |
-| ui.ingress.enabled | bool | `false` | Create an Ingress for the user and admin Web UI |
+| ui.ingress.enabled | bool | `false` | Create an Ingress for the user and admin Web UI. |
 | ui.ingress.className | string | `""` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | ui.ingress.annotations | object | `{}` | Annotations to be added to the Ingress. |
 | ui.ingress.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -136,6 +136,16 @@ require at least one port.
 | service.ports.http.nodePort | int | `nil` | REST API node port (when applicable). |
 | service.externalTrafficPolicy | string | `nil` | Route external traffic to node-local or cluster-wide endoints. Useful for [preserving the client source IP](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip). |
 | services | object | `{}` | Additional services exposing servers (SFTP, FTP, WebDAV, HTTP) individually. The schema matches the one under the `service` key. Additional services need at least one port. |
+| ingress.app.enabled | bool | `false` | Create an Ingress for the user and admin Web UI |
+| ingress.app.className | string | `nil` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.app.annotations | object | `{}` | Annotations to be added to the Ingress. |
+| ingress.app.hosts | object | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.app.tls | object | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.api.enabled | bool | `false` | Create an Ingress for the API and health endpoint. |
+| ingress.api.className | string | `nil` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.api.annotations | object | `{}` | Annotations to be added to the Ingress. |
+| ingress.api.hosts | object | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.api.tls | object | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling configuration (see [values.yaml](values.yaml) for details). |
 | nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration. |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.8.1](https://img.shields.io/badge/version-0.8.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.1.0](https://img.shields.io/badge/app%20version-2.1.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.9.0](https://img.shields.io/badge/version-0.9.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.1.0](https://img.shields.io/badge/app%20version-2.1.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -144,7 +144,7 @@ require at least one port.
 | api.ingress.enabled | bool | `false` | Create an Ingress for the API and health endpoint. |
 | api.ingress.className | string | `""` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | api.ingress.annotations | object | `{}` | Annotations to be added to the Ingress. |
-| api.ingress.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. sftpgo does not change the path for the health check and API endpoint if httpd.web_root is set. So, we need to rewrite these paths to the root. |
+| api.ingress.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. sftpgo does not change the path for the API endpoint if httpd.web_root is set. So, we need to rewrite to the root path. |
 | api.ingress.tls | list | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling configuration (see [values.yaml](values.yaml) for details). |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.9.1-1](https://img.shields.io/badge/version-0.9.1--1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.1.0](https://img.shields.io/badge/app%20version-2.1.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.9.0](https://img.shields.io/badge/version-0.9.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.1.0](https://img.shields.io/badge/app%20version-2.1.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -137,15 +137,15 @@ require at least one port.
 | service.externalTrafficPolicy | string | `nil` | Route external traffic to node-local or cluster-wide endoints. Useful for [preserving the client source IP](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip). |
 | services | object | `{}` | Additional services exposing servers (SFTP, FTP, WebDAV, HTTP) individually. The schema matches the one under the `service` key. Additional services need at least one port. |
 | ingress.app.enabled | bool | `false` | Create an Ingress for the user and admin Web UI |
-| ingress.app.className | string | `nil` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.app.className | string | `""` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | ingress.app.annotations | object | `{}` | Annotations to be added to the Ingress. |
-| ingress.app.hosts | object | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
-| ingress.app.tls | object | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.app.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.app.tls | list | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | ingress.api.enabled | bool | `false` | Create an Ingress for the API and health endpoint. |
-| ingress.api.className | string | `nil` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.api.className | string | `""` | Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | ingress.api.annotations | object | `{}` | Annotations to be added to the Ingress. |
-| ingress.api.hosts | object | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
-| ingress.api.tls | object | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.api.hosts | list | `[]` | List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
+| ingress.api.tls | list | `[]` | List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details. |
 | resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
 | autoscaling | object | Disabled by default. | Autoscaling configuration (see [values.yaml](values.yaml) for details). |
 | nodeSelector | object | `{}` | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration. |

--- a/charts/sftpgo/templates/ingress-api.yaml
+++ b/charts/sftpgo/templates/ingress-api.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.api.enabled -}}
+{{- $fullName := include "sftpgo.fullname" . -}}
+{{- $svcPort := .Values.service.ports.http.port -}}
+{{- if and .Values.ingress.api.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.api.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.api.annotations "kubernetes.io/ingress.class" .Values.ingress.api.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-api
+  labels:
+    {{- include "sftpgo.labels" . | nindent 4 }}
+  {{- with .Values.ingress.api.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.api.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.api.className }}
+  {{- end }}
+  {{- if .Values.ingress.api.tls }}
+  tls:
+    {{- range .Values.ingress.api.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.api.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/sftpgo/templates/ingress-api.yaml
+++ b/charts/sftpgo/templates/ingress-api.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.ingress.api.enabled -}}
+{{- if .Values.api.ingress.enabled -}}
 {{- $fullName := include "sftpgo.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
-{{- if and .Values.ingress.api.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.api.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.api.annotations "kubernetes.io/ingress.class" .Values.ingress.api.className}}
+{{- if and .Values.api.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.api.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.api.ingress.annotations "kubernetes.io/ingress.class" .Values.api.ingress.className}}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -18,17 +18,17 @@ metadata:
   name: {{ include "sftpgo.componentname" (list . "api") }}
   labels:
     {{- include "sftpgo.labels" . | nindent 4 }}
-  {{- with .Values.ingress.api.annotations }}
+  {{- with .Values.api.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.api.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.api.className }}
+  {{- if and .Values.api.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.api.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.api.tls }}
+  {{- if .Values.api.ingress.tls }}
   tls:
-    {{- range .Values.ingress.api.tls }}
+    {{- range .Values.api.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -37,7 +37,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.api.hosts }}
+    {{- range .Values.api.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/charts/sftpgo/templates/ingress-api.yaml
+++ b/charts/sftpgo/templates/ingress-api.yaml
@@ -15,7 +15,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-api
+  name: {{ include "sftpgo.componentname" (list . "api") }}
   labels:
     {{- include "sftpgo.labels" . | nindent 4 }}
   {{- with .Values.ingress.api.annotations }}

--- a/charts/sftpgo/templates/ingress-ui.yaml
+++ b/charts/sftpgo/templates/ingress-ui.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.ingress.app.enabled -}}
+{{- if .Values.ui.ingress.enabled -}}
 {{- $fullName := include "sftpgo.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
-{{- if and .Values.ingress.app.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.app.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.app.annotations "kubernetes.io/ingress.class" .Values.ingress.app.className}}
+{{- if and .Values.ui.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ui.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ui.ingress.annotations "kubernetes.io/ingress.class" .Values.ui.ingress.className}}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -18,17 +18,17 @@ metadata:
   name: {{ include "sftpgo.componentname" (list . "ui") }}
   labels:
     {{- include "sftpgo.labels" . | nindent 4 }}
-  {{- with .Values.ingress.app.annotations }}
+  {{- with .Values.ui.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.app.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.app.className }}
+  {{- if and .Values.ui.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ui.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.app.tls }}
+  {{- if .Values.ui.ingress.tls }}
   tls:
-    {{- range .Values.ingress.app.tls }}
+    {{- range .Values.ui.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -37,7 +37,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.app.hosts }}
+    {{- range .Values.ui.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/charts/sftpgo/templates/ingress-ui.yaml
+++ b/charts/sftpgo/templates/ingress-ui.yaml
@@ -15,7 +15,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-ui
+  name: {{ include "sftpgo.componentname" (list . "ui") }}
   labels:
     {{- include "sftpgo.labels" . | nindent 4 }}
   {{- with .Values.ingress.app.annotations }}

--- a/charts/sftpgo/templates/ingress-ui.yaml
+++ b/charts/sftpgo/templates/ingress-ui.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.app.enabled -}}
+{{- $fullName := include "sftpgo.fullname" . -}}
+{{- $svcPort := .Values.service.ports.http.port -}}
+{{- if and .Values.ingress.app.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.app.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.app.annotations "kubernetes.io/ingress.class" .Values.ingress.app.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-ui
+  labels:
+    {{- include "sftpgo.labels" . | nindent 4 }}
+  {{- with .Values.ingress.app.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.app.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.app.className }}
+  {{- end }}
+  {{- if .Values.ingress.app.tls }}
+  tls:
+    {{- range .Values.ingress.app.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.app.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -163,6 +163,44 @@ services: {}
   #       nodePort:
   #   externalTrafficPolicy:
 
+# -- Ingress for the web interface
+# Change httpd.web_root in the sftpgo configuration if you change the path
+ingress:
+  # Ingress for the Web UIs (user and admin interface)
+  app:
+    enabled: true
+    className: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts: []
+    #  - host: chart-example.local
+    #    paths:
+    #      - path: /
+    #        pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  # Ingress for the API endpoint
+  api:
+    enabled: false
+    className: ""
+    annotations: {}
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts: []
+    #  - host: chart-example.local
+    #    paths:
+    #      - path: /(api/.*|healthz)$
+    #        pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
 # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
 # @default -- No requests or limits.

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -163,9 +163,9 @@ services: {}
   #       nodePort:
   #   externalTrafficPolicy:
 
-ingress:
+ui:
   # Ingress for the Web UIs (user and admin interface)
-  app:
+  ingress:
     # -- Create an Ingress for the user and admin Web UI
     enabled: false
     # -- Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
@@ -189,8 +189,9 @@ ingress:
     #    hosts:
     #      - chart-example.local
 
+api:
   # Ingress for the API endpoint
-  api:
+  ingress:
     # -- Create an Ingress for the API and health endpoint.
     enabled: false
     # -- Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
@@ -202,6 +203,7 @@ ingress:
       # kubernetes.io/tls-acme: "true"
 
     # -- List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
+    # sftpgo does not change the path for the health check and API endpoint if httpd.web_root is set. So, we need to rewrite these paths to the root.
     hosts: []
     #  - host: chart-example.local
     #    paths:

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -166,7 +166,7 @@ services: {}
 ui:
   # Ingress for the Web UIs (user and admin interface)
   ingress:
-    # -- Create an Ingress for the user and admin Web UI
+    # -- Create an Ingress for the user and admin Web UI.
     enabled: false
     # -- Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
     className: ""

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -203,11 +203,11 @@ api:
       # kubernetes.io/tls-acme: "true"
 
     # -- List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
-    # sftpgo does not change the path for the health check and API endpoint if httpd.web_root is set. So, we need to rewrite these paths to the root.
+    # sftpgo does not change the path for the API endpoint if httpd.web_root is set. So, we need to rewrite to the root path.
     hosts: []
     #  - host: chart-example.local
     #    paths:
-    #      - path: /(api/.*|healthz)$
+    #      - path: /api/(.*)
     #        pathType: ImplementationSpecific
 
     # -- List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -163,21 +163,27 @@ services: {}
   #       nodePort:
   #   externalTrafficPolicy:
 
-# -- Ingress for the web interface
-# Change httpd.web_root in the sftpgo configuration if you change the path
 ingress:
   # Ingress for the Web UIs (user and admin interface)
   app:
-    enabled: true
+    # -- Create an Ingress for the user and admin Web UI
+    enabled: false
+    # -- Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
     className: ""
+    # -- Annotations to be added to the Ingress.
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+
+    # -- List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
     hosts: []
     #  - host: chart-example.local
+    #    # Change httpd.web_root in the sftpgo configuration if you change the path
     #    paths:
     #      - path: /
     #        pathType: ImplementationSpecific
+
+    # -- List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
@@ -185,17 +191,24 @@ ingress:
 
   # Ingress for the API endpoint
   api:
+    # -- Create an Ingress for the API and health endpoint.
     enabled: false
+    # -- Ingress class name. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
     className: ""
+    # -- Annotations to be added to the Ingress.
     annotations: {}
       # nginx.ingress.kubernetes.io/rewrite-target: /$1
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+
+    # -- List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
     hosts: []
     #  - host: chart-example.local
     #    paths:
     #      - path: /(api/.*|healthz)$
     #        pathType: ImplementationSpecific
+
+    # -- List of TLS secrets. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -203,6 +203,7 @@ api:
       # kubernetes.io/tls-acme: "true"
 
     # -- List of virtual hosts. See [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for details.
+
     # sftpgo does not change the path for the API endpoint if httpd.web_root is set. So, we need to rewrite to the root path.
     hosts: []
     #  - host: chart-example.local


### PR DESCRIPTION
Add Ingress support for sftpgo. Actually, this change optionally provides two Ingresses: One for the user and admin UI, and one for the API and health endpoint. The reason for having two Ingresses is that sftpgo can change the web root for the UI part only. So, UI and API need different treatment.

Signed-off-by: Stephan Austermühle <au@hcsd.de>