### PR TITLE
sftpgo: Support Topology Spread Constraints

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.7.1
+version: 0.8.0
 appVersion: 2.1.0
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.7.1](https://img.shields.io/badge/version-0.7.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.1.0](https://img.shields.io/badge/app%20version-2.1.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.8.0](https://img.shields.io/badge/version-0.8.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.1.0](https://img.shields.io/badge/app%20version-2.1.0-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 
@@ -142,7 +142,8 @@ require at least one port.
 | tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for node taints. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | hostNetwork | bool | `false` | Run pods in the host network of nodes. Warning: The use of host network is [discouraged](https://kubernetes.io/docs/concepts/configuration/overview/#services). Make sure to use it only when absolutely necessary. |
-| topologySpreadConstraints.enabled | bool | `false` | Enable Kubernetes [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) |
+| topologySpreadConstraints | object | `{"enabled":false,"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"DoNotSchedule"}` | Configure Pod [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) Requires Kubernetes >= v1.16 |
+| topologySpreadConstraints.enabled | bool | `false` | Enable Kubernetes [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). Note: Request Kubernetes v1.16+. |
 | topologySpreadConstraints.maxSkew | int | `1` | Degree to which Pods may be unevenly distributed |
-| topologySpreadConstraints.topologyKey | string | `topology.kubernetes.io/zone` | Topology key |
-| topologySpreadConstraints.whenUnsatisfiable | string | `DoNotSchedule` | How to deal with a Pod if it doesn't satisfy the spread constraint |
+| topologySpreadConstraints.topologyKey | string | `"topology.kubernetes.io/zone"` | Topology key See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/ |
+| topologySpreadConstraints.whenUnsatisfiable | string | `"DoNotSchedule"` | How to deal with a Pod if it doesn't satisfy the spread constraint |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -142,3 +142,7 @@ require at least one port.
 | tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for node taints. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | affinity | object | `{}` | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details. |
 | hostNetwork | bool | `false` | Run pods in the host network of nodes. Warning: The use of host network is [discouraged](https://kubernetes.io/docs/concepts/configuration/overview/#services). Make sure to use it only when absolutely necessary. |
+| topologySpreadConstraints.enabled | bool | `false` | Enable Kubernetes [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) |
+| topologySpreadConstraints.maxSkew | int | `1` | Degree to which Pods may be unevenly distributed |
+| topologySpreadConstraints.topologyKey | string | `topology.kubernetes.io/zone` | Topology key |
+| topologySpreadConstraints.whenUnsatisfiable | string | `DoNotSchedule` | How to deal with a Pod if it doesn't satisfy the spread constraint |

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -136,11 +136,11 @@ spec:
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- if .Values.topologySpreadConstraints.enabled }}
       topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            {{- include "sftpgo.selectorLabels" . | nindent 12 }}
-        maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
-        topologyKey: {{ .Values.topologySpreadConstraints.topologyKey }}
-        whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+        - labelSelector:
+            matchLabels:
+              {{- include "sftpgo.selectorLabels" . | nindent 12 }}
+          maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
+          topologyKey: {{ .Values.topologySpreadConstraints.topologyKey }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
 {{- end }}
 {{- end }}

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -133,3 +133,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Values.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            {{- include "sftpgo.selectorLabels" . | nindent 12 }}
+        maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
+        topologyKey: {{ .Values.topologySpreadConstraints.topologyKey }}
+        whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+{{- end }}
+{{- end }}

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -201,3 +201,12 @@ affinity: {}
 # -- Run pods in the host network of nodes.
 # Warning: The use of host network is [discouraged](https://kubernetes.io/docs/concepts/configuration/overview/#services). Make sure to use it only when absolutely necessary.
 hostNetwork: false
+
+# -- Configure Pod [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
+# Requires Kubernetes >= v1.16
+topologySpreadConstraints:
+  enabled: false
+  maxSkew: 1
+  # See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: DoNotSchedule

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -205,8 +205,12 @@ hostNetwork: false
 # -- Configure Pod [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 # Requires Kubernetes >= v1.16
 topologySpreadConstraints:
+  # -- Enable Kubernetes [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/). Note: Request Kubernetes v1.16+.
   enabled: false
+  # -- Degree to which Pods may be unevenly distributed
   maxSkew: 1
+  # -- Topology key
   # See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/
   topologyKey: topology.kubernetes.io/zone
+  # -- How to deal with a Pod if it doesn't satisfy the spread constraint
   whenUnsatisfiable: DoNotSchedule


### PR DESCRIPTION
This PR adds support for [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)

Signed-off-by: Stephan Austermühle <au@hcsd.de>