### PR TITLE
Restart deployment if config has been changes

### DIFF
--- a/charts/dex-k8s-authenticator/templates/deployment.yaml
+++ b/charts/dex-k8s-authenticator/templates/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "dex-k8s-authenticator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "dex-k8s-authenticator.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
If config has been changed, not restart of the pod happens.

This forced a restart of the pod, if the content of the secret has been changed.

See also: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments