### PR TITLE
feat(chart/tusd): add initContainers as input values

### DIFF
--- a/charts/tusd/templates/deployment.yaml
+++ b/charts/tusd/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
       serviceAccountName: {{ include "tusd.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/tusd/values.yaml
+++ b/charts/tusd/values.yaml
@@ -24,6 +24,8 @@ nameOverride: ""
 # -- A name to substitute for the full names of resources.
 fullnameOverride: ""
 
+# [Init Containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
+initContainers: []
 # -- Additional storage [volumes](https://kubernetes.io/docs/concepts/storage/volumes/).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details.
 volumes: []


### PR DESCRIPTION
Init containers are useful in tusd while initializing persistence
volumes or fixing permissions. I had to use init containers to fix
permission issue caused by openebs nfs provisioner.

Contributing back so that it could be useful to others