### PR TITLE
add `httpd.enabled` toggle

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.10.1
+version: 0.11.0
 appVersion: 2.2.1
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.10.1](https://img.shields.io/badge/version-0.10.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.11.0](https://img.shields.io/badge/version-0.11.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 
@@ -110,6 +110,7 @@ require at least one port.
 | sftpd.enabled | bool | `true` | Enable SFTP service. |
 | ftpd.enabled | bool | `false` | Enable FTP service. |
 | webdavd.enabled | bool | `false` | Enable WebDAV service. |
+| httpd.enabled | bool | `true` | Enable HTTP service. |
 | config | object | `{}` | Application configuration. See the [official documentation](https://github.com/drakkan/sftpgo/blob/master/docs/full-configuration.md). |
 | volumes | list | `[]` | Additional storage [volumes](https://kubernetes.io/docs/concepts/storage/volumes/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |
 | volumeMounts | list | `[]` | Additional [volume mounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1) for details. |

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -56,10 +56,15 @@ spec:
             - name: SFTPGO_WEBDAVD__BINDINGS__0__ADDRESS
               value: "0.0.0.0"
             {{- end }}
+            {{- if .Values.httpd.enabled }}
             - name: SFTPGO_HTTPD__BINDINGS__0__PORT
               value: "8080"
             - name: SFTPGO_HTTPD__BINDINGS__0__ADDRESS
               value: "0.0.0.0"
+            {{- else }}
+            - name: SFTPGO_HTTPD__BINDINGS__0__PORT
+              value: "0"
+            {{- end }}
             - name: SFTPGO_TELEMETRY__BIND_PORT
               value: "10000"
             - name: SFTPGO_TELEMETRY__BIND_ADDRESS
@@ -91,9 +96,11 @@ spec:
               containerPort: 8081
               protocol: TCP
             {{- end }}
+            {{- if .Values.httpd.enabled }}
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- end }}
             - name: telemetry
               containerPort: 10000
               protocol: TCP

--- a/charts/sftpgo/templates/ingress-api.yaml
+++ b/charts/sftpgo/templates/ingress-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.ingress.enabled -}}
+{{- if and $.Values.httpd.enabled .Values.api.ingress.enabled -}}
 {{- $fullName := include "sftpgo.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
 {{- if and .Values.api.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}

--- a/charts/sftpgo/templates/ingress-ui.yaml
+++ b/charts/sftpgo/templates/ingress-ui.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ui.ingress.enabled -}}
+{{- if and $.Values.httpd.enabled .Values.ui.ingress.enabled -}}
 {{- $fullName := include "sftpgo.fullname" . -}}
 {{- $svcPort := .Values.service.ports.http.port -}}
 {{- if and .Values.ui.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}

--- a/charts/sftpgo/templates/service.yaml
+++ b/charts/sftpgo/templates/service.yaml
@@ -58,6 +58,7 @@ spec:
       appProtocol: webdav
       {{- end }}
     {{- end }}
+    {{- if .Values.httpd.enabled }}
     - name: http
       port: {{ .Values.service.ports.http.port }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.ports.http.nodePort }}
@@ -68,6 +69,7 @@ spec:
       {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion }}
       appProtocol: http
       {{- end }}
+    {{- end }}
     - name: telemetry
       port: 10000
       targetPort: telemetry
@@ -140,7 +142,7 @@ spec:
       appProtocol: webdav
       {{- end }}
     {{- end }}
-    {{- if $service.ports.http }}
+    {{- if and $.Values.httpd.enabled $service.ports.http }}
     - name: http
       port: {{ required (printf "HTTP service port is required for service %q" $name) $service.ports.http.port }}
       {{- if and (or (eq $service.type "NodePort") (eq $service.type "LoadBalancer")) $service.ports.http.nodePort }}

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -36,6 +36,10 @@ webdavd:
   # -- Enable WebDAV service.
   enabled: false
 
+httpd:
+  # -- Enable HTTP service.
+  enabled: true
+
 # -- Application configuration.
 # See the [official documentation](https://github.com/drakkan/sftpgo/blob/master/docs/full-configuration.md).
 config: {}


### PR DESCRIPTION
Closes #122 

This patch introduces a new setting, `httpd.enabled`

By default, this value is `true`. 

If it is set to `false`, the HTTP service will no longer be exposed, and the `SFTPGO_HTTPD__BINDINGS__0__PORT` environmental variable will set the port binding to `0` (which prevents SFTPGo from launching the HTTP daemon altogether).