### PR TITLE
Add support for externalIPs in Kubernetes Services

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.11.0
+version: 0.12.0
 appVersion: 2.2.1
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.11.0](https://img.shields.io/badge/version-0.11.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.11.0-asa-1](https://img.shields.io/badge/version-0.11.0--asa--1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 
@@ -127,6 +127,7 @@ require at least one port.
 | service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | service.loadBalancerIP | string | `nil` | Only applies when the service type is LoadBalancer. Load balancer will get created with the IP specified in this field. |
 | service.loadBalancerSourceRanges | list | `[]` | (list) If specified (and supported by the cloud provider), traffic through the load balancer will be restricted to the specified client IPs. Valid values are IP CIDR blocks. |
+| service.externalIPs | list | `[]` | (list) Expose service on the named IPs. Note that Kubernetes does [not take care of assigning the IP address the nodes](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips). External IPs that route to one or more cluster nodes |
 | service.ports.sftp.port | int | `22` | SFTP service port. |
 | service.ports.sftp.nodePort | int | `nil` | SFTP node port (when applicable). |
 | service.ports.ftp.port | int | `21` | FTP service port. |

--- a/charts/sftpgo/templates/service.yaml
+++ b/charts/sftpgo/templates/service.yaml
@@ -18,8 +18,13 @@ spec:
   loadBalancerIP: {{ . }}
   {{- end }}
   {{- with .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ toYaml . | nindent 4 }}
+  loadBalancerSourceRanges:
+    {{ toYaml . | nindent 4 }}
   {{- end }}
+  {{- end }}
+  {{- with .Values.service.externalIPs }}
+  externalIPs:
+    {{ toYaml . | indent 4 }}
   {{- end }}
   ports:
     {{- if .Values.sftpd.enabled }}
@@ -102,8 +107,13 @@ spec:
   loadBalancerIP: {{ . }}
   {{- end }}
   {{- with $service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ toYaml . | nindent 4 }}
+  loadBalancerSourceRanges:
+    {{ toYaml . | nindent 4 }}
   {{- end }}
+  {{- end }}
+  {{- with $service.externalIPs }}
+  externalIPs:
+    {{ toYaml . | indent 4 }}
   {{- end }}
   ports:
     {{- if and $.Values.sftpd.enabled $service.ports.sftp }}

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -120,6 +120,10 @@ service:
   # Valid values are IP CIDR blocks.
   loadBalancerSourceRanges: []
 
+  # -- (list) Expose service on the named IPs. Note that Kubernetes does [not take care of assigning the IP address the nodes](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips).
+  # External IPs that route to one or more cluster nodes
+  externalIPs: []
+
   ports:
     sftp:
       # -- SFTP service port.
@@ -161,6 +165,7 @@ services: {}
   #   type: LoadBalancer
   #   loadBalancerIP:
   #   loadBalancerSourceRanges: []
+  #   externalIPs: []
   #   ports:
   #     sftp: # Only SFTP will be exposed
   #       port: 22


### PR DESCRIPTION
This PR adds support for configuring [`externalIPs`](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips) in Kubernetes Services.

Also fixes Helm syntax error for loadBalancerSourceRanges

Signed-off-by: Stephan Austermühle <au@hcsd.de>