### PR TITLE
Support shared and persistent signing passphrase for sftpgo

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.11.0
+version: 0.12.0
 appVersion: 2.2.1
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -157,3 +157,7 @@ require at least one port.
 | topologySpreadConstraints.maxSkew | int | `1` | Degree to which pods may be unevenly distributed. |
 | topologySpreadConstraints.topologyKey | string | `"topology.kubernetes.io/zone"` | The key of node labels. See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/ |
 | topologySpreadConstraints.whenUnsatisfiable | string | `"DoNotSchedule"` | How to deal with a Pod if it doesn't satisfy the spread constraint. |
+| sftpgo | object | `{"signingPassphrase":{"enabled":false,"secretKey":"passphrase","secretName":""}}` | `sftpgo` application configuration |
+| sftpgo.signingPassphrase.enabled | bool | `false` | (bool) Use an existing or create a Kubernetes Secret holding the passphrase to use for deriving the signing key for JWT and CSRF tokens. This is required when running more than one sftpgo instance and to keep tokens valid across server restarts. Consider using a suitable external database (e.g., Postgres), too. See https://github.com/drakkan/sftpgo/blob/main/docs/full-configuration.md for more information on `httpd.signing_passphrase` and https://github.com/drakkan/sftpgo/issues/466. |
+| sftpgo.signingPassphrase.secretName | string | `""` | (string) Name of an existing Kubernetes Secret holding the passphrase. Leave empty to auto-generate the secret. |
+| sftpgo.signingPassphrase.secretKey | string | `"passphrase"` | (string) Name of the key in the Kubernetes Secret holding the actual passphrase |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.11.0](https://img.shields.io/badge/version-0.11.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.12.0](https://img.shields.io/badge/version-0.12.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 

--- a/charts/sftpgo/templates/_helpers.tpl
+++ b/charts/sftpgo/templates/_helpers.tpl
@@ -73,3 +73,10 @@ Usage: {{ include "sftpgo.componentname" (list . "component") }}
 {{- $component := index . 1 | trimPrefix "-" -}}
 {{- printf "%s-%s" (include "sftpgo.fullname" $global | trunc (sub 62 (len $component) | int) | trimSuffix "-" ) $component | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name for the signing passphrase secret
+*/}}
+{{- define "sftpgo.signingPassphraseName" -}}
+{{- include "sftpgo.componentname" (list . "signingpass") -}}
+{{- end -}}

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -65,6 +65,13 @@ spec:
             - name: SFTPGO_HTTPD__BINDINGS__0__PORT
               value: "0"
             {{- end }}
+{{- if .Values.sftpgo.signingPassphrase.enabled }}
+            - name: SFTPGO_HTTPD__SIGNING_PASSPHRASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "sftpgo.signingPassphraseName" .) .Values.sftpgo.signingPassphrase.secretName }}
+                  key: {{ .Values.sftpgo.signingPassphrase.secretKey }}
+{{- end }}
             - name: SFTPGO_TELEMETRY__BIND_PORT
               value: "10000"
             - name: SFTPGO_TELEMETRY__BIND_ADDRESS

--- a/charts/sftpgo/templates/secret.yaml
+++ b/charts/sftpgo/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.sftpgo.signingPassphrase.enabled (not .Values.sftpgo.signingPassphrase.secretName) }}
+{{- $signingPassphrase := (randAlphaNum 32) | b64enc | quote }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "sftpgo.signingPassphraseName" .)) }}
+{{- if $secret }}
+{{- $signingPassphrase = get $secret.data .Values.sftpgo.signingPassphrase.secretKey }}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "sftpgo.signingPassphraseName" . }}
+  labels:
+    {{- include "sftpgo.labels" . | nindent 4 }}
+data:
+  {{ .Values.sftpgo.signingPassphrase.secretKey }}: {{ $signingPassphrase }}
+{{- end }}

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -278,3 +278,20 @@ topologySpreadConstraints:
 
   # -- How to deal with a Pod if it doesn't satisfy the spread constraint.
   whenUnsatisfiable: DoNotSchedule
+
+# -- `sftpgo` application configuration
+sftpgo:
+
+  # Enable sharing the sftpgo signing passphrase across multiple instances
+  # Note: Requires sftpgo 2.2.0 or later
+  signingPassphrase:
+
+    # -- (bool) Use an existing or create a Kubernetes Secret holding the passphrase to use for deriving the signing key for JWT and CSRF tokens. This is required when running more than one sftpgo instance and to keep tokens valid across server restarts. Consider using a suitable external database (e.g., Postgres), too.
+    # See https://github.com/drakkan/sftpgo/blob/main/docs/full-configuration.md for more information on `httpd.signing_passphrase` and https://github.com/drakkan/sftpgo/issues/466.
+    enabled: false
+
+    # -- (string) Name of an existing Kubernetes Secret holding the passphrase. Leave empty to auto-generate the secret.
+    secretName: ""
+
+    # -- (string) Name of the key in the Kubernetes Secret holding the actual passphrase
+    secretKey: passphrase


### PR DESCRIPTION
This PR adds support for a shared and persistent signing passphrase that `sftpgo` uses to derive the signing key for JWT and CSRF tokens. This is required when running more than one sftpgo instance and to keep tokens valid across server restarts. Otherwise, every `sftpgo` instance computes its own passphrase on startup that does not accept tokens from other or previous instances. See also https://github.com/drakkan/sftpgo/issues/466.

For compatibility reasons, the feature is disabled by default.

Signed-off-by: Stephan Austermühle <au@hcsd.de>