### PR TITLE
Allow creation of default admin account

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.11.0
+version: 0.12.0
 appVersion: 2.2.1
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.12.0
+version: 0.11.0-asa-7
 appVersion: 2.2.1
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.11.0-asa-7
+version: 0.13.0
 appVersion: 2.2.1
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.12.0](https://img.shields.io/badge/version-0.12.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.13.0](https://img.shields.io/badge/version-0.13.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 
@@ -157,7 +157,12 @@ require at least one port.
 | topologySpreadConstraints.maxSkew | int | `1` | Degree to which pods may be unevenly distributed. |
 | topologySpreadConstraints.topologyKey | string | `"topology.kubernetes.io/zone"` | The key of node labels. See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/ |
 | topologySpreadConstraints.whenUnsatisfiable | string | `"DoNotSchedule"` | How to deal with a Pod if it doesn't satisfy the spread constraint. |
-| sftpgo | object | `{"signingPassphrase":{"enabled":false,"secretKey":"passphrase","secretName":""}}` | `sftpgo` application configuration |
+| sftpgo | object | `{"defaultAdmin":{"enabled":true,"passwordKey":"password","secretName":"","username":"admin","usernameKey":"username"},"signingPassphrase":{"enabled":false,"secretKey":"passphrase","secretName":""}}` | `sftpgo` application configuration |
+| sftpgo.defaultAdmin.enabled | bool | `true` | (bool) Create a default admin account. sftpgo v2.1.0 and later no longer create a default admin account unless requested. |
+| sftpgo.defaultAdmin.username | string | `"admin"` | (string) Default admin account name |
+| sftpgo.defaultAdmin.secretName | string | `""` | (string) Name of an existing Kubernetes Secret holding the admin account credentials. Leave empty to auto-generate the secret. |
+| sftpgo.defaultAdmin.usernameKey | string | `"username"` | (string) Name of the key in the Kubernetes Secret holding the default admin account name |
+| sftpgo.defaultAdmin.passwordKey | string | `"password"` | (string) Name of the key in the Kubernetes Secret holding the default admin account password (this is _not_ the actual password!) |
 | sftpgo.signingPassphrase.enabled | bool | `false` | (bool) Use an existing or create a Kubernetes Secret holding the passphrase to use for deriving the signing key for JWT and CSRF tokens. This is required when running more than one sftpgo instance and to keep tokens valid across server restarts. Consider using a suitable external database (e.g., Postgres), too. See https://github.com/drakkan/sftpgo/blob/main/docs/full-configuration.md for more information on `httpd.signing_passphrase` and https://github.com/drakkan/sftpgo/issues/466. |
 | sftpgo.signingPassphrase.secretName | string | `""` | (string) Name of an existing Kubernetes Secret holding the passphrase. Leave empty to auto-generate the secret. |
 | sftpgo.signingPassphrase.secretKey | string | `"passphrase"` | (string) Name of the key in the Kubernetes Secret holding the actual passphrase |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -157,3 +157,7 @@ require at least one port.
 | topologySpreadConstraints.maxSkew | int | `1` | Degree to which pods may be unevenly distributed. |
 | topologySpreadConstraints.topologyKey | string | `"topology.kubernetes.io/zone"` | The key of node labels. See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/ |
 | topologySpreadConstraints.whenUnsatisfiable | string | `"DoNotSchedule"` | How to deal with a Pod if it doesn't satisfy the spread constraint. |
+| sftpgo | object | `{"signingPassphrase":{"enabled":false,"secretKey":"passphrase","secretName":""}}` | `sftpgo` application configuration |
+| sftpgo.signingPassphrase.enabled | bool | `false` | (bool) Use an existing or create a Kubernetes Secret holding the passphrase to use for deriving the signing key for JWT and CSRF tokens. This is required when running more than one sftpgo instance and to keep tokens valid across server restarts. Consider using a suitable external database (e.g., Postgres), too. See https://github.com/drakkan/sftpgo/blob/main/docs/full-configuration.md for more information on `httpd.signing_passphrase` and https://github.com/drakkan/sftpgo/issues/466. |
+| sftpgo.signingPassphrase.secretName | string | `""` | (string) Name of an existing Kubernetes Secret holding the passphrase. Leave empty to auto-generate the secret. |
+| sftpgo.signingPassphrase.secretKey | string | `"passphrase"` | (string) Name of the key in the Kubernetes Secret holding the actual passphrase |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.11.0](https://img.shields.io/badge/version-0.11.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.12.0](https://img.shields.io/badge/version-0.12.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.2.1](https://img.shields.io/badge/app%20version-2.2.1-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 

--- a/charts/sftpgo/templates/_helpers.tpl
+++ b/charts/sftpgo/templates/_helpers.tpl
@@ -73,3 +73,10 @@ Usage: {{ include "sftpgo.componentname" (list . "component") }}
 {{- $component := index . 1 | trimPrefix "-" -}}
 {{- printf "%s-%s" (include "sftpgo.fullname" $global | trunc (sub 62 (len $component) | int) | trimSuffix "-" ) $component | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name for the signing passphrase secret
+*/}}
+{{- define "sftpgo.signingPassphraseName" -}}
+{{- include "sftpgo.componentname" (list . "signingpass") -}}
+{{- end -}}

--- a/charts/sftpgo/templates/_helpers.tpl
+++ b/charts/sftpgo/templates/_helpers.tpl
@@ -80,3 +80,10 @@ Create the name for the signing passphrase secret
 {{- define "sftpgo.signingPassphraseName" -}}
 {{- include "sftpgo.componentname" (list . "signingpass") -}}
 {{- end -}}
+
+{{/*
+Create the name for the default admin account secret
+*/}}
+{{- define "sftpgo.adminAccount" -}}
+{{- include "sftpgo.componentname" (list . "admin") -}}
+{{- end -}}

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -65,6 +65,13 @@ spec:
             - name: SFTPGO_HTTPD__BINDINGS__0__PORT
               value: "0"
             {{- end }}
+{{- if .Values.sftpgo.signingPassphrase.enabled }}
+            - name: SFTPGO_HTTPD__SIGNING_PASSPHRASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "sftpgo.signingPassphraseName" .) .Values.sftpgo.signingPassphrase.secretName }}
+                  key: {{ .Values.sftpgo.signingPassphrase.secretKey }}
+{{- end }}
             - name: SFTPGO_TELEMETRY__BIND_PORT
               value: "10000"
             - name: SFTPGO_TELEMETRY__BIND_ADDRESS

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -65,6 +65,20 @@ spec:
             - name: SFTPGO_HTTPD__BINDINGS__0__PORT
               value: "0"
             {{- end }}
+{{- if .Values.sftpgo.defaultAdmin.enabled }}
+            - name: SFTPGO_DATA_PROVIDER__CREATE_DEFAULT_ADMIN
+              value: "true"
+            - name: SFTPGO_DEFAULT_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "sftpgo.adminAccount" .) .Values.sftpgo.defaultAdmin.secretName }}
+                  key: {{ .Values.sftpgo.defaultAdmin.usernameKey }}
+            - name: SFTPGO_DEFAULT_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ default (include "sftpgo.adminAccount" .) .Values.sftpgo.defaultAdmin.secretName }}
+                  key: {{ .Values.sftpgo.defaultAdmin.passwordKey }}
+{{- end }}
 {{- if .Values.sftpgo.signingPassphrase.enabled }}
             - name: SFTPGO_HTTPD__SIGNING_PASSPHRASE
               valueFrom:

--- a/charts/sftpgo/templates/secret.yaml
+++ b/charts/sftpgo/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.sftpgo.signingPassphrase.enabled (not .Values.sftpgo.signingPassphrase.secretName) }}
+{{- $signingPassphrase := (randAlphaNum 32) | b64enc | quote }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "sftpgo.signingPassphraseName" .)) }}
+{{- if $secret }}
+{{- $signingPassphrase = get $secret.data .Values.sftpgo.signingPassphrase.secretKey }}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "sftpgo.signingPassphraseName" . }}
+  labels:
+    {{- include "sftpgo.labels" . | nindent 4 }}
+data:
+  {{ .Values.sftpgo.signingPassphrase.secretKey }}: {{ $signingPassphrase }}
+{{- end }}

--- a/charts/sftpgo/templates/secret.yaml
+++ b/charts/sftpgo/templates/secret.yaml
@@ -14,3 +14,24 @@ metadata:
 data:
   {{ .Values.sftpgo.signingPassphrase.secretKey }}: {{ $signingPassphrase }}
 {{- end }}
+
+---
+{{ if .Values.sftpgo.defaultAdmin.enabled }}
+{{- $username := .Values.sftpgo.defaultAdmin.username | b64enc | quote }}
+{{- $password := (randAlphaNum 32) | b64enc | quote }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "sftpgo.adminAccount" .)) }}
+{{- if $secret }}
+{{- $username = get $secret.data .Values.sftpgo.defaultAdmin.usernameKey }}
+{{- $password = get $secret.data .Values.sftpgo.defaultAdmin.passwordKey }}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "sftpgo.adminAccount" . }}
+  labels:
+    {{- include "sftpgo.labels" . | nindent 4 }}
+data:
+  {{ .Values.sftpgo.defaultAdmin.usernameKey }}: {{ $username }}
+  {{ .Values.sftpgo.defaultAdmin.passwordKey }}: {{ $password }}
+{{- end }}

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -278,3 +278,20 @@ topologySpreadConstraints:
 
   # -- How to deal with a Pod if it doesn't satisfy the spread constraint.
   whenUnsatisfiable: DoNotSchedule
+
+# -- `sftpgo` application configuration
+sftpgo:
+
+  # Enable sharing the sftpgo signing passphrase across multiple instances
+  # Note: Requires sftpgo 2.2.0 or later
+  signingPassphrase:
+
+    # -- (bool) Use an existing or create a Kubernetes Secret holding the passphrase to use for deriving the signing key for JWT and CSRF tokens. This is required when running more than one sftpgo instance and to keep tokens valid across server restarts. Consider using a suitable external database (e.g., Postgres), too.
+    # See https://github.com/drakkan/sftpgo/blob/main/docs/full-configuration.md for more information on `httpd.signing_passphrase` and https://github.com/drakkan/sftpgo/issues/466.
+    enabled: false
+
+    # -- (string) Name of an existing Kubernetes Secret holding the passphrase. Leave empty to auto-generate the secret.
+    secretName: ""
+
+    # -- (string) Name of the key in the Kubernetes Secret holding the actual passphrase
+    secretKey: passphrase

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -282,6 +282,24 @@ topologySpreadConstraints:
 # -- `sftpgo` application configuration
 sftpgo:
 
+  defaultAdmin:
+
+    # -- (bool) Create a default admin account.
+    # sftpgo v2.1.0 and later no longer create a default admin account unless requested.
+    enabled: true
+
+    # -- (string) Default admin account name
+    username: admin
+
+    # -- (string) Name of an existing Kubernetes Secret holding the admin account credentials. Leave empty to auto-generate the secret.
+    secretName: ""
+
+    # -- (string) Name of the key in the Kubernetes Secret holding the default admin account name
+    usernameKey: username
+
+    # -- (string) Name of the key in the Kubernetes Secret holding the default admin account password (this is _not_ the actual password!)
+    passwordKey: password
+
   # Enable sharing the sftpgo signing passphrase across multiple instances
   # Note: Requires sftpgo 2.2.0 or later
   signingPassphrase:


### PR DESCRIPTION
Unless an initial user database is provided, `sftpgo` creates the default/initial admin account through the UI. This PR allows creation of the default admin account through the Helm chart.

This PR builds on top of #130, so flagging this as draft for the time being.