### PR TITLE
Update example config value

### DIFF
--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -28,7 +28,7 @@ Setting the `config` key in the values file is the easiest way to configure SFTP
 ```yaml
 config:
     sftpd:
-        max_auth_retries: 10
+        max_auth_tries: 10
 ```
 
 ### Custom volume mount
@@ -56,7 +56,7 @@ metadata:
 data:
   sftpgo.yaml: |-
     sftpd:
-        max_auth_retries: 10
+        max_auth_tries: 10
 ```
 
 ```yaml


### PR DESCRIPTION
I cannot find `max_auth_retries` in the [Configuring SFTPGo](https://github.com/drakkan/sftpgo/blob/main/docs/full-configuration.md) section. Instead, I see `max_auth_tries`, so I thought to update it, just to avoid confusion.