### PR TITLE
fix(sftpgo): match the app.kubernetes.io/version label to the image tag

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -21,6 +21,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: Match the app.kubernetes.io/version label to the image tag
+    - kind: changed
+      description: Updated sftpgo to 2.4.3
   artifacthub.io/images: |
     - name: sftpgo
       image: ghcr.io/drakkan/sftpgo:v2.4.3

--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -23,6 +23,6 @@ annotations:
       description: Match the app.kubernetes.io/version label to the image tag
   artifacthub.io/images: |
     - name: sftpgo
-      image: ghcr.io/drakkan/sftpgo:v2.4.2
+      image: ghcr.io/drakkan/sftpgo:v2.4.3
     - name: sftpgo-alpine
-      image: ghcr.io/drakkan/sftpgo:v2.4.2-alpine
+      image: ghcr.io/drakkan/sftpgo:v2.4.3-alpine

--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -19,8 +19,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Config for deployment strategy and init containers
+    - kind: fixed
+      description: Match the app.kubernetes.io/version label to the image tag
   artifacthub.io/images: |
     - name: sftpgo
       image: ghcr.io/drakkan/sftpgo:v2.4.2

--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.14.1
+version: 0.14.2
 appVersion: 2.4.3
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 name: sftpgo
 version: 0.14.1
-appVersion: 2.4.2
+appVersion: 2.4.3
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 keywords:

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.14.1](https://img.shields.io/badge/version-0.14.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.4.2](https://img.shields.io/badge/app%20version-2.4.2-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.14.2](https://img.shields.io/badge/version-0.14.2-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.4.3](https://img.shields.io/badge/app%20version-2.4.3-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 

--- a/charts/sftpgo/templates/_helpers.tpl
+++ b/charts/sftpgo/templates/_helpers.tpl
@@ -37,7 +37,11 @@ Common labels
 helm.sh/chart: {{ include "sftpgo.chart" . }}
 {{ include "sftpgo.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) | quote }}
+{{- if .Values.image.tag }}
+app.kubernetes.io/version: {{ .Values.image.tag | trimPrefix "v" | quote }}
+{{- else }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/sftpgo/templates/_helpers.tpl
+++ b/charts/sftpgo/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "sftpgo.chart" . }}
 {{ include "sftpgo.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}

--- a/charts/sftpgo/templates/_helpers.tpl
+++ b/charts/sftpgo/templates/_helpers.tpl
@@ -36,12 +36,10 @@ Common labels
 {{- define "sftpgo.labels" -}}
 helm.sh/chart: {{ include "sftpgo.chart" . }}
 {{ include "sftpgo.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
 {{- if .Values.image.tag }}
 app.kubernetes.io/version: {{ .Values.image.tag | trimPrefix "v" | quote }}
-{{- else }}
+{{- else if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}


### PR DESCRIPTION
Currently if you override image.tag the label app.kubernetes.io/version still uses appVersion in Chart.yaml.