### PR TITLE
feat(sftpgo): mount config json as file instead of path

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.14.1
+version: 0.15.0
 appVersion: 2.4.2
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
@@ -19,8 +19,8 @@ maintainers:
     url: https://sagikazarmark.hu
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Config for deployment strategy and init containers
+    - kind: changed
+      description: Mount config json as file instead of path
   artifacthub.io/images: |
     - name: sftpgo
       image: ghcr.io/drakkan/sftpgo:v2.4.2

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -124,7 +124,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/sftpgo
+              mountPath: /etc/sftpgo/sftpgo.json
+              subPath: sftpgo.json
               readOnly: true
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
This leaves other things (currently just `/etc/sftpgo/moduli`) in place, to make it easier to enable diffie-hellman key exchange.

This file was added in [sftpgo 2.4.2 ](https://github.com/drakkan/sftpgo/releases/tag/v2.4.2)
https://github.com/drakkan/sftpgo/blob/v2.4.2/Dockerfile#L50
https://github.com/drakkan/sftpgo/commit/29d1993a3b302e0e0499801aff2b53aa014beca7
