### PR TITLE
Adds tpl function to podAnnotations to enable checksumming

### DIFF
--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       labels:
         {{- include "sftpgo.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
I use a user configuration file which gets mounted into the sftpgo pod via volume and volumeMounts. Since adding or removing users changes the config map I would like to let the pods restart such that the new config map is loaded. 
This can be achieved via a checksum function in the podAnnotations section in deplyments.yaml and adding the calculation within values.yaml.

`
sftpgo:     
  podAnnotations:     
    configmap/checksum: '{{ include (print $.Template.BasePath "/user-config.yaml") . | sha256sum }}'    
`
This is only possible if the podAnnotations uses the "tpl" function.