### PR TITLE
autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated.

### DIFF
--- a/charts/sftpgo/templates/hpa.yaml
+++ b/charts/sftpgo/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "sftpgo.fullname" . }}


### PR DESCRIPTION
autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler.