### PR TITLE
chart/sftpgo: Feature/add pv support for sqlite default db

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.19.0
+version: 0.20.0
 appVersion: 2.5.4
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -160,3 +160,5 @@ require at least one port.
 | topologySpreadConstraints.maxSkew | int | `1` | Degree to which pods may be unevenly distributed. |
 | topologySpreadConstraints.topologyKey | string | `"topology.kubernetes.io/zone"` | The key of node labels. See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/ |
 | topologySpreadConstraints.whenUnsatisfiable | string | `"DoNotSchedule"` | How to deal with a Pod if it doesn't satisfy the spread constraint. |
+| persistence.enabled | bool | `false` | Enable persistent storage for the /var/lib/sftpgo directory, saving state of the sqlite db stored there by default. Requires the user select a spec for the desired PVC. |
+| persistence.pvc | object | `{}` | Create the desired pvc specificiation to use. |

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.19.0](https://img.shields.io/badge/version-0.19.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.5.4](https://img.shields.io/badge/app%20version-2.5.4-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.20.0](https://img.shields.io/badge/version-0.20.0-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.5.4](https://img.shields.io/badge/app%20version-2.5.4-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 
@@ -122,7 +122,7 @@ require at least one port.
 | serviceAccount.annotations | object | `{}` | Annotations to be added to the service account. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | podAnnotations | object | `{}` | Annotations to be added to pods. |
-| podSecurityContext | object | `{}` | Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details. |
+| podSecurityContext | object | `{"fsGroup":1000}` | Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details. |
 | securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 | initContainers | list | `[]` | Add [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to the pod. |
 | service.annotations | object | `{}` | Annotations to be added to the service. |
@@ -160,5 +160,5 @@ require at least one port.
 | topologySpreadConstraints.maxSkew | int | `1` | Degree to which pods may be unevenly distributed. |
 | topologySpreadConstraints.topologyKey | string | `"topology.kubernetes.io/zone"` | The key of node labels. See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/ |
 | topologySpreadConstraints.whenUnsatisfiable | string | `"DoNotSchedule"` | How to deal with a Pod if it doesn't satisfy the spread constraint. |
-| persistence.enabled | bool | `false` | Enable persistent storage for the /var/lib/sftpgo directory, saving state of the sqlite db stored there by default. Requires the user select a spec for the desired PVC. |
-| persistence.pvc | object | `{}` | Create the desired pvc specificiation to use. |
+| persistence.enabled | bool | `false` | Enable persistent storage for the /var/lib/sftpgo directory, saving state of the default sqlite db. |
+| persistence.pvc | object | `{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"5Gi"}},"storageClassName":"premium-rwo"}` | Create the pvc desired specificiation. |

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -127,6 +127,10 @@ spec:
               mountPath: /etc/sftpgo/sftpgo.json
               subPath: sftpgo.json
               readOnly: true
+          {{- if .Values.persistence.enabled }}
+            - mountPath: /var/lib/sftpgo
+              name: sftpgo-volume
+          {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -134,6 +138,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "sftpgo.fullname" . }}
+      {{- if .Values.persistence.enabled }}
+        - name: sftpgo-volume
+          persistentVolumeClaim:
+            claimName: {{ include "sftpgo.fullname" . }}-pvc
+      {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/sftpgo/templates/pvc.yaml
+++ b/charts/sftpgo/templates/pvc.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  finalizers:
+  - kubernetes.io/pvc-protection
+  name: {{ include "sftpgo.fullname" . }}-pvc
+  labels:
+    {{- include "sftpgo.labels" . | nindent 4 }}
+spec:
+  {{- toYaml .Values.persistence.pvc | nindent 2 }}
+{{- end }}

--- a/charts/sftpgo/templates/pvc.yaml
+++ b/charts/sftpgo/templates/pvc.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   finalizers:
-  - kubernetes.io/pvc-protection
-  name: {{ include "sftpgo.fullname" . }}-pvc
+    - kubernetes.io/pvc-protection
+  name: {{ include "sftpgo.fullname" . }}
   labels:
     {{- include "sftpgo.labels" . | nindent 4 }}
 spec:

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -96,18 +96,19 @@ podAnnotations: {}
 
 # -- Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details.
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 1000
 
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
-securityContext: {}
+securityContext:
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
-  # runAsUser: 1000
+  runAsUser: 1000  # User ID under which your app runs
+  runAsGroup: 1000  # Group ID under which your app runs
 
 # -- Add [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to the pod.
 initContainers: []
@@ -289,3 +290,16 @@ topologySpreadConstraints:
 
   # -- How to deal with a Pod if it doesn't satisfy the spread constraint.
   whenUnsatisfiable: DoNotSchedule
+
+# -- Enable persistent storage for the /var/lib/sftpgo directory, saving state of a memory db.
+persistence:
+  enabled: true
+
+  # -- Create the pvc desired specificiation.
+  pvc:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5Gi
+    storageClassName: premium-rwo

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -290,7 +290,7 @@ topologySpreadConstraints:
   whenUnsatisfiable: DoNotSchedule
 
 persistence:
-  # -- Enable persistent storage for the /var/lib/sftpgo directory, saving state of a memory db.
+  # -- Enable persistent storage for the /var/lib/sftpgo directory, saving state of the default sqlite db.
   enabled: false
 
   # -- Create the pvc desired specificiation.

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -101,14 +101,12 @@ podSecurityContext:
 
 # -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
-securityContext:
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
-  runAsUser: 1000  # User ID under which your app runs
-  runAsGroup: 1000  # Group ID under which your app runs
 
 # -- Add [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to the pod.
 initContainers: []
@@ -291,14 +289,14 @@ topologySpreadConstraints:
   # -- How to deal with a Pod if it doesn't satisfy the spread constraint.
   whenUnsatisfiable: DoNotSchedule
 
-# -- Enable persistent storage for the /var/lib/sftpgo directory, saving state of a memory db.
 persistence:
+  # -- Enable persistent storage for the /var/lib/sftpgo directory, saving state of a memory db.
   enabled: false
 
   # -- Create the pvc desired specificiation.
   pvc:
     accessModes:
-    - ReadWriteOnce
+      - ReadWriteOnce
     resources:
       requests:
         storage: 5Gi

--- a/charts/sftpgo/values.yaml
+++ b/charts/sftpgo/values.yaml
@@ -293,7 +293,7 @@ topologySpreadConstraints:
 
 # -- Enable persistent storage for the /var/lib/sftpgo directory, saving state of a memory db.
 persistence:
-  enabled: true
+  enabled: false
 
   # -- Create the pvc desired specificiation.
   pvc:


### PR DESCRIPTION
My attempt at adding a PVC to the chart that addresses adding persistent storage for sqlite db used by default in /var/lib/sftpgo. Am open to feedback and testing from the community!

Addresses #3 #121