### PR TITLE
feat(sftpgo): allow deployment to automatically rollout when configmap is updated

### DIFF
--- a/charts/sftpgo/Chart.yaml
+++ b/charts/sftpgo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sftpgo
-version: 0.23.1
+version: 0.23.2
 appVersion: 2.5.4
 kubeVersion: ">=1.16.0-0"
 description: Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.

--- a/charts/sftpgo/README.md
+++ b/charts/sftpgo/README.md
@@ -1,6 +1,6 @@
 # sftpgo
 
-![version: 0.23.1](https://img.shields.io/badge/version-0.23.1-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.5.4](https://img.shields.io/badge/app%20version-2.5.4-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
+![version: 0.23.2](https://img.shields.io/badge/version-0.23.2-informational?style=flat-square) ![type: application](https://img.shields.io/badge/type-application-informational?style=flat-square) ![app version: 2.5.4](https://img.shields.io/badge/app%20version-2.5.4-informational?style=flat-square) ![kube version: >=1.16.0-0](https://img.shields.io/badge/kube%20version->=1.16.0--0-informational?style=flat-square) [![artifact hub](https://img.shields.io/badge/artifact%20hub-sftpgo-informational?style=flat-square)](https://artifacthub.io/packages/helm/sagikazarmark/sftpgo)
 
 Fully featured and highly configurable SFTP server with optional FTP/S and WebDAV support.
 

--- a/charts/sftpgo/templates/deployment.yaml
+++ b/charts/sftpgo/templates/deployment.yaml
@@ -21,8 +21,9 @@ spec:
       {{- include "sftpgo.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Hey there 👋 

Small PR to allow the deployment to automatically rollout when the configuration in the configmap is updated.

The technique used here (injecting the checksum of the configmap in the pod annotations) is well known and is used in others public helm charts:
- https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/templates/_helpers.tpl#L244
- https://github.com/grafana/helm-charts/blob/main/charts/grafana/templates/deployment.yaml#L36
- https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/templates/deployment.yaml#L28

Don't hesitate to reach me if needed

Cheers ☀️ 