### PR TITLE
chore: add podLabels to deployment

### DIFF
--- a/charts/browserless-chrome/Chart.yaml
+++ b/charts/browserless-chrome/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: browserless-chrome
-version: 0.0.4
+version: 0.0.5
 appVersion: "1.48.0"
 kubeVersion: ">=1.16.0-0"
 description: Chrome as a service container. Bring your own hardware or cloud.

--- a/charts/browserless-chrome/README.md
+++ b/charts/browserless-chrome/README.md
@@ -43,6 +43,7 @@ Check out the [official documentation](https://docs.browserless.io/docs/docker.h
 | serviceAccount.annotations | object | `{}` | Annotations to be added to the service account. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | podAnnotations | object | `{}` | Annotations to be added to pods. |
+| podLabels | object | `{}` | Labels to be added to pods. |
 | podSecurityContext | object | `{}` | Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details. |
 | securityContext | object | `{}` | Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details. |
 | service.annotations | object | `{}` | Annotations to be added to the service. |

--- a/charts/browserless-chrome/templates/deployment.yaml
+++ b/charts/browserless-chrome/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "browserless-chrome.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/browserless-chrome/values.yaml
+++ b/charts/browserless-chrome/values.yaml
@@ -54,6 +54,9 @@ serviceAccount:
 # -- Annotations to be added to pods.
 podAnnotations: {}
 
+# -- Labels to be added to pods.
+podLabels: {}
+
 # -- Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details.
 podSecurityContext: {}


### PR DESCRIPTION
- This updates the Chart to 0.0.5 and adds to ability to specify pod labels for the deployment, similar to what's already there for annotations.